### PR TITLE
updated remote repository in ccp-nlp-wrapper-banner to new location

### DIFF
--- a/ccp-nlp-wrapper-banner/pom.xml
+++ b/ccp-nlp-wrapper-banner/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>ccp-nlp</artifactId>
@@ -55,7 +56,11 @@
 	<repositories>
 		<repository>
 			<id>ren-maven-repo</id>
-			<url>https://ren-maven-repo.googlecode.com/git/snapshots</url>
+			<url>https://raw.githubusercontent.com/renaud/maven_repo/master/snapshots/</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
 		</repository>
 		<repository>
 			<id>bionlp-sourceforge</id>


### PR DESCRIPTION
was previously on google-code, but now is on github